### PR TITLE
Attempt to expose trustServerCertificate configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A node-red node to execute queries and stored procedures in Microsoft SQL Server and Azure Databases SQL2000 ~ SQL2019",
   "main": "odbc.js",
   "dependencies": {
-    "mssql": "^6.2.1",
+    "mssql": "next",
     "mustache": "^4.0.1"
   },
   "devDependencies": {

--- a/src/mssql.html
+++ b/src/mssql.html
@@ -69,6 +69,11 @@
           <div class="form-tips">SQL Databases hosted on Azure will need this checked</div>
       </div>
       <div class="form-row mssql-plus-form-row">
+        <label for="node-config-input-trustServerCertificate"><i class="fa fa-lock"></i> Trust Server Certificate?</label>
+        <input type="checkbox" id="node-config-input-trustServerCertificate">
+        <div class="form-tips">Permits connecting to a server that presents an otherwise untrusted certificate</div>
+    </div>
+      <div class="form-row mssql-plus-form-row">
           <label for="node-config-input-useUTC"><i class="fa fa-clock-o"></i> Assume UTC?</label>
           <input type="checkbox" id="node-config-input-useUTC">
           <div class="form-tips">Pass time values in UTC or local time.</div>
@@ -123,6 +128,9 @@
             },
             encyption: {
                 value: true
+            },
+            trustServerCertificate: {
+                value: false
             },
             database: {
                 value: "",

--- a/src/mssql.js
+++ b/src/mssql.js
@@ -206,6 +206,7 @@ module.exports = function (RED) {
                 port: config.port ? safeParseInt(config.port, 1433) : undefined,
                 tdsVersion: config.tdsVersion || "7_4",
                 encrypt: config.encyption,
+                trustServerCertificate: config.trustServerCertificate,
                 useUTC: config.useUTC,
                 connectTimeout: config.connectTimeout ? safeParseInt(config.connectTimeout, 15000) : undefined,
                 requestTimeout: config.requestTimeout ? safeParseInt(config.requestTimeout, 15000) : undefined,


### PR DESCRIPTION
Hi there,

This adjustment exposes the `trustServerCertificate` configuration option:

<img width="498" alt="Screen Shot 2020-08-26 at 1 11 10 PM" src="https://user-images.githubusercontent.com/10692146/91243840-fb964600-e79e-11ea-8dd3-7e53761b5bf9.png">

I have also bumped the mssql dependency to "next", but hopefully you can ignore this change to the packages.json file if you decide to merge the changes in.

Many thanks !