### PR TITLE
Prevent node-red crash on exit

### DIFF
--- a/src/mssql.js
+++ b/src/mssql.js
@@ -335,7 +335,7 @@ module.exports = function (RED) {
             // node-mssql 5.x to 6.x changes
             // ConnectionPool.close() now returns a promise / callbacks will be executed once closing of the
             if (node.pool && node.pool.close) {
-                node.pool && node.pool.close().catch(() => {})
+                node.pool.close().catch(() => {})
             }
             if (updateStatusAndLog) node.status({ fill: 'grey', shape: 'dot', text: 'disconnected' });
             node.poolConnect = null;

--- a/src/mssql.js
+++ b/src/mssql.js
@@ -331,9 +331,11 @@ module.exports = function (RED) {
                 }
             } catch (error) {
             }
-            try {
-                if (node.pool) node.pool.close();
-            } catch (error) {
+
+            // node-mssql 5.x to 6.x changes
+            // ConnectionPool.close() now returns a promise / callbacks will be executed once closing of the
+            if (node.pool && node.pool.close) {
+                node.pool && node.pool.close().catch(() => {})
             }
             if (updateStatusAndLog) node.status({ fill: 'grey', shape: 'dot', text: 'disconnected' });
             node.poolConnect = null;


### PR DESCRIPTION
_handle_ the fact `pool.close` is now a promise.

This fix is only to contain the issue raised in #91 

A future change is necessary to make the `node.on('close', ` callback should be async and the `.disconnect` through to `connectionCleanup` functions should await so that we correctly inform node-red that it is OK to close

```
        node.on('close', function () {
            mssqlCN.disconnect(node.id);
        });
```


NOTE: this is untested - will request review before merge.