### PR TITLE
Ensure examples dir is included in pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     }
   },
   "files": [
-    "src/"
+    "src/",
+    "examples/"
   ],
   "directories": {
     "example": "examples"


### PR DESCRIPTION
Add examples to the `files` array so that it is included in the installed system