### PR TITLE
Fix ineffective `parseMustache` option

### DIFF
--- a/src/mssql.html
+++ b/src/mssql.html
@@ -416,11 +416,11 @@
             return this.name ? 'node_label_italic' : '';
         },
         oneditprepare: function () {
-            if (this.parseMustache === undefined) {
-                this.parseMustache = true;
+            const node = this;
+            if (typeof node.parseMustache === 'undefined') {
+                node.parseMustache = true;
                 $('#node-input-parseMustache').prop('checked', true);
             }
-            const node = this;
             //ensure node.query is a string otherwise editor wont initialise
             if (typeof node.query !== 'string') node.query = '';
             //create the query editor

--- a/src/mssql.js
+++ b/src/mssql.js
@@ -752,10 +752,12 @@ module.exports = function (RED) {
                 }
             }
 
+            let doMustache = false;
+            const promises = [];
+            const resolvedTokens = {};
             if (node.parseMustache) {
-                const promises = [];
                 const tokens = extractTokens(mustache.parse(msg.query));
-                const resolvedTokens = {};
+                doMustache = tokens.length > 0;
                 tokens.forEach(function (name) {
                     const envName = parseEnv(name);
                     if (envName) {
@@ -789,7 +791,8 @@ module.exports = function (RED) {
                         }
                     }
                 });
-
+            }
+            if (doMustache) {
                 Promise.all(promises).then(function () {
                     const value = mustache.render(msg.query, new NodeContext(msg, node.context(), null, false, resolvedTokens));
                     msg.query = value;

--- a/src/mssql.js
+++ b/src/mssql.js
@@ -757,7 +757,7 @@ module.exports = function (RED) {
             const resolvedTokens = {};
             if (node.parseMustache) {
                 const tokens = extractTokens(mustache.parse(msg.query));
-                doMustache = tokens.length > 0;
+                doMustache = tokens.size > 0;
                 tokens.forEach(function (name) {
                     const envName = parseEnv(name);
                     if (envName) {

--- a/src/mssql.js
+++ b/src/mssql.js
@@ -496,7 +496,7 @@ module.exports = function (RED) {
         node.paramsOptType = config.paramsOptType || 'none';
         node.rows = config.rows || 'rows';
         node.rowsType = config.rowsType || 'msg';
-        node.parseMustache = config.parseMustache || true;
+        node.parseMustache = !(config.parseMustache === false || config.parseMustache === 'false'); // if not explicitly set to false, then enable mustache parsing
 
         const setResult = function (msg, field, value, returnType = 0) {
             // eslint-disable-next-line eqeqeq

--- a/src/mssql.js
+++ b/src/mssql.js
@@ -752,12 +752,11 @@ module.exports = function (RED) {
                 }
             }
 
-            let doMustache = false;
             const promises = [];
             const resolvedTokens = {};
+            let tokens;
             if (node.parseMustache) {
-                const tokens = extractTokens(mustache.parse(msg.query));
-                doMustache = tokens.size > 0;
+                tokens = extractTokens(mustache.parse(msg.query));
                 tokens.forEach(function (name) {
                     const envName = parseEnv(name);
                     if (envName) {
@@ -792,7 +791,7 @@ module.exports = function (RED) {
                     }
                 });
             }
-            if (doMustache) {
+            if (tokens && tokens.size > 0) {
                 Promise.all(promises).then(function () {
                     const value = mustache.render(msg.query, new NodeContext(msg, node.context(), null, false, resolvedTokens));
                     msg.query = value;

--- a/src/mssql.js
+++ b/src/mssql.js
@@ -335,7 +335,7 @@ module.exports = function (RED) {
             // node-mssql 5.x to 6.x changes
             // ConnectionPool.close() now returns a promise / callbacks will be executed once closing of the
             if (node.pool && node.pool.close) {
-                node.pool.close().catch(() => {})
+                node.pool.close().catch(() => {});
             }
             if (updateStatusAndLog) node.status({ fill: 'grey', shape: 'dot', text: 'disconnected' });
             node.poolConnect = null;


### PR DESCRIPTION
The new option to disable mustache parsing did not work due to an incorrect falsy check.

This PR does:
* Ensure setting for `parseMustache` is respected
* Skips mustache rendering if no tokens exist in the the query (auto skip mustache rendering)
* A little code tidy and linting

