### PR TITLE
Update MSSQL to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [18, 20, 22]
 
     env:
       SA_PASSWORD: "P@ssw0rdP@ssw0rd"

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
   "name": "node-red-contrib-mssql-plus",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "A node-red node to execute queries, stored procedures and bulk inserts in Microsoft SQL Server and Azure Databases SQL2000 ~ SQL2022",
   "main": "odbc.js",
   "dependencies": {
-    "mssql": "^10.0.0",
+    "mssql": "^11.0.1",
     "mustache": "^4.2.0"
   },
   "devDependencies": {
-    "eslint": "^7.25.0",
-    "eslint-config-standard": "^16.0.2",
-    "eslint-plugin-html": "^6.1.2",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint": "^7.32.0",
+    "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-html": "^6.2.0",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.3.1",
-    "mocha": "^9.2.0",
-    "node-red": "^1.0.3",
-    "node-red-node-test-helper": "^0.3.0",
+    "mocha": "^9.2.2",
+    "node-red": "^4.0.9",
+    "node-red-node-test-helper": "^0.3.4",
     "should": "^13.2.3"
   },
   "node-red": {
@@ -62,6 +62,6 @@
     "url": "https://github.com/bestlong/node-red-contrib-mssql-plus/issues"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
Updates Mssql to latest version 11.0.1
Bumps this package to next minor semver `0.13.0` to reflect the change in node version requirements.

# NOTE: Mssql drops support for Node V16 and below.

FWIW: "Node.js 16 reached its end-of-life (EOL) on September 11, 2023."

<br>

Other updates (to dev deps) were made to remove all of the high and all of the critical audit vulns:

### Before:
```
41 vulnerabilities (5 low, 14 moderate, 16 high, 6 critical)
```

### After:
```
3 moderate severity vulnerabilities
```



